### PR TITLE
Move async API for 3.7 compatibility

### DIFF
--- a/erequests.py
+++ b/erequests.py
@@ -15,7 +15,7 @@ import eventlet
 # Monkey-patch.
 requests = eventlet.patcher.import_patched('requests.__init__')
 
-__all__ = ['__version__', 'map', 'imap', 'get', 'options', 'head', 'post', 'put', 'patch', 'delete', 'request', 'async', 'AsyncRequest']
+__all__ = ['__version__', 'map', 'imap', 'get', 'options', 'head', 'post', 'put', 'patch', 'delete', 'request', 'AsyncRequest']
 
 # Export same items as vanilla requests
 __requests_imports__ = ['utils', 'session', 'Session', 'codes', 'RequestException', 'Timeout', 'URLRequired', 'TooManyRedirects', 'HTTPError', 'ConnectionError']
@@ -97,10 +97,6 @@ class AsyncRequestFactory(object):
         return cls.request('DELETE', url, **kwargs)
 
 
-# alias for the factory
-async = AsyncRequestFactory
-
-
 def request(method, url, **kwargs):
     req = AsyncRequest(method, url)
     return eventlet.spawn(req.send, **kwargs).wait()
@@ -135,6 +131,23 @@ def patch(url, data=None, **kwargs):
 
 def delete(url, **kwargs):
     return request('DELETE', url, **kwargs)
+
+
+def request_async(*args, **kwargs): return AsyncRequestFactory.request(*args, **kwargs)
+
+def get_async(*args, **kwargs): return AsyncRequestFactory.get(*args, **kwargs)
+
+def options_async(*args, **kwargs): return AsyncRequestFactory.options(*args, **kwargs)
+
+def head_async(*args, **kwargs): return AsyncRequestFactory.head(*args, **kwargs)
+
+def post_async(*args, **kwargs): return AsyncRequestFactory.post(*args, **kwargs)
+
+def put_async(*args, **kwargs): return AsyncRequestFactory.put(*args, **kwargs)
+
+def patch_async(*args, **kwargs): return AsyncRequestFactory.patch(*args, **kwargs)
+
+def delete_async(*args, **kwargs): return AsyncRequestFactory.delete(*args, **kwargs)
 
 
 def map(requests, size=10):

--- a/tests/test_erequests.py
+++ b/tests/test_erequests.py
@@ -25,12 +25,12 @@ URLS = [httpbin('get?p=%s' % i) for i in range(N)]
 class GrequestsCase(unittest.TestCase):
 
     def test_map(self):
-        reqs = [erequests.async.get(url) for url in URLS]
+        reqs = [erequests.get_async(url) for url in URLS]
         resp = erequests.map(reqs, size=N)
         self.assertEqual([r.url for r in resp], URLS)
 
     def test_imap(self):
-        reqs = (erequests.async.get(url) for url in URLS)
+        reqs = (erequests.get_async(url) for url in URLS)
         i = 0
         for i, r in enumerate(erequests.imap(reqs, size=N)):
             self.assertTrue(r.url in URLS)
@@ -43,7 +43,7 @@ class GrequestsCase(unittest.TestCase):
             result[r.url] = True
             return r
 
-        reqs = [erequests.async.get(url, hooks={'response': [hook]}) for url in URLS]
+        reqs = [erequests.get_async(url, hooks={'response': [hook]}) for url in URLS]
         resp = list(erequests.map(reqs, size=N))
         self.assertEqual(sorted(result.keys()), sorted(URLS))
 
@@ -71,25 +71,25 @@ class GrequestsCase(unittest.TestCase):
         self.assertEqual(r['cookies'], c3)
 
     def test_calling_request(self):
-        reqs = [erequests.async.request('POST', httpbin('post'), data={'p': i})
+        reqs = [erequests.request_async('POST', httpbin('post'), data={'p': i})
                 for i in range(N)]
         resp = erequests.map(reqs, size=N)
         self.assertEqual([int(r.json()['form']['p']) for r in resp], list(range(N)))
 
     def test_stream_enabled(self):
-        r = list(erequests.map([erequests.async.get(httpbin('stream/10'), stream=True)],
+        r = list(erequests.map([erequests.get_async(httpbin('stream/10'), stream=True)],
                           size=2))[0]
         self.assertFalse(r._content_consumed)
 
     def test_concurrency_with_delayed_url(self):
         t = time.time()
         n = 10
-        reqs = [erequests.async.get(httpbin('delay/1')) for _ in range(n)]
+        reqs = [erequests.get_async(httpbin('delay/1')) for _ in range(n)]
         resp = list(erequests.map(reqs, size=n))
         self.assertLess((time.time() - t), n)
 
     def get(self, url, **kwargs):
-        return list(erequests.map([erequests.async.get(url, **kwargs)]))[0]
+        return list(erequests.map([erequests.get_async(url, **kwargs)]))[0]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #6.

The big block of _async functions feel clunky, but I'm not aware of a more concise representation.